### PR TITLE
[feature] Add client side array filter

### DIFF
--- a/src/js/svc-countries.js
+++ b/src/js/svc-countries.js
@@ -4,35 +4,37 @@
 
   angular.module("risevision.core.countries", ["risevision.common.gapi"])
 
-  .factory("getCoreCountries", ["coreAPILoader", "$q", "$log",
-      function (coreAPILoader, $q, $log) {
-        var deferred;
-        return function () {
-          if (deferred) {
-            return deferred.promise;
-          }
-          else {
-            deferred = $q.defer();  
-          }
-          
-          coreAPILoader().then(function (coreApi) {
-            return coreApi.country.list();
-          })
-          .then(function (resp) {
-            var items = resp.result;
-            if(!(items instanceof Array) && items.items) { items = items.items; }
-
-            deferred.resolve(items);
-          })
-          .then(null, function(e) {
-            $log.debug("getCoreCountries failed", e);
-            deferred.reject(e);
-            
-            deferred = null;
-          });
+  .factory("getCoreCountries", ["coreAPILoader", "$q", "$log", "$filter",
+    function (coreAPILoader, $q, $log, $filter) {
+      var deferred;
+      return function () {
+        if (deferred) {
           return deferred.promise;
-        };
-    }])
+        }
+        else {
+          deferred = $q.defer();  
+        }
+        
+        coreAPILoader().then(function (coreApi) {
+          return coreApi.country.list();
+        })
+        .then(function (resp) {
+          var items = resp.result ? resp.result.items : [];
+          if(items instanceof Array) { 
+            items = $filter("orderBy")(items, "name");
+          }
+
+          deferred.resolve(items);
+        })
+        .then(null, function(e) {
+          $log.debug("getCoreCountries failed", e);
+          deferred.reject(e);
+          
+          deferred = null;
+        });
+        return deferred.promise;
+      };
+  }])
   .factory("COUNTRIES", ["getCoreCountries", 
     function (getCoreCountries) {
       var countries = [];

--- a/test/unit/svc-countries-spec.js
+++ b/test/unit/svc-countries-spec.js
@@ -14,7 +14,63 @@ describe("Services: Countries Core API Service", function() {
               setTimeout(function () {
                 def.resolve({
                   result: {
-                    items: []
+                    items: [
+                      {
+                       "code": "US",
+                       "name": "United States",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "EG",
+                       "name": "Egypt",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "GB",
+                       "name": "United Kingdom",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "FR",
+                       "name": "France",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "GR",
+                       "name": "Greece",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "RO",
+                       "name": "Romania",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "AT",
+                       "name": "Austria",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "PT",
+                       "name": "Portugal",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "BR",
+                       "name": "Brazil",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "CA",
+                       "name": "Canada",
+                       "kind": "core#countryItem"
+                      },
+                      {
+                       "code": "TR",
+                       "name": "Turkey",
+                       "kind": "core#countryItem"
+                      }
+                    ]
                   }
                 });
               }, 0);
@@ -51,6 +107,16 @@ describe("Services: Countries Core API Service", function() {
       .then(function(result){
         expect(result).to.be.truely;
         expect(result).to.be.an.array;
+        done();
+      })
+      .then(null,done);
+    });
+    
+    it("should order by name",function(done){
+      getCoreCountries()
+      .then(function(result){
+        expect(result[0].name).to.equal("Austria");
+        expect(result[result.length - 1].name).to.equal("United States");
         done();
       })
       .then(null,done);


### PR DESCRIPTION
Tried to use a filter parameter for this request, but it didn't work. I don't believe `sort` is implemented for this API.

So, instead of forcing every list to have its own filter, implemented the filter in the service. I don't see any instance when we don't want this list to be ordered by name.

@olegrise please review. Thanks!