### PR TITLE
Fix Sub Companies search

### DIFF
--- a/src/js/svc-company.js
+++ b/src/js/svc-company.js
@@ -233,7 +233,7 @@
       var createSearchQuery = function(fields, search) {
         var query = "";
         
-        for (var i in fields) {
+        for (var i=0; i<fields.length;i++) {
           query += "OR " + fields[i] + ":~\'" + search + "\' ";
         }
         

--- a/test/unit/svc-company-spec.js
+++ b/test/unit/svc-company-spec.js
@@ -163,6 +163,14 @@ describe("Services: Company Core API Service", function() {
         done();
       })
     });
+
+    it("should get companies regardless of additional Array fields", function (done) {
+      Array.prototype.contains = function(){};
+      companyService.getCompanies("some_id", "s").then(function (result) {
+        expect(result).to.deep.equal(rvFixtures.companiesResp);
+        done();
+      })
+    });
   });
 
   xdescribe("getSubCompanies", function () {


### PR DESCRIPTION
Fix array loop. When adding extra array fields with Array.prototype, it was looping to the additional field and adding it to query, messing up with the search.

Staged at https://developer-stage.risevision.com/

@alex-deaconu Please review. Thanks